### PR TITLE
Add borderless window to ac2 (uplay edition)

### DIFF
--- a/EaglePatch/src/ac2.cpp
+++ b/EaglePatch/src/ac2.cpp
@@ -1,6 +1,9 @@
+#define WIN32_LEAN_AND_MEAN 1
 #include <Windows.h>
+
 #include <stdio.h>
 #include <stdint.h>
+#include <utility>
 #include <Xinput.h>
 
 #include "patcher.h"
@@ -42,6 +45,8 @@ struct sAddresses
 	static uintptr_t _AddHWGraphicObjectInstances_checkIsCharacter_jumpOut;
 	static uintptr_t HackPlayerOptionsSaveData;
 	static uintptr_t ClassSerializer_EndClass;
+	static char* g_byte_IsFullscreen;
+	static uintptr_t _BorderlessWindow_Zeromemory_D3dPresentParameters;
 };
 
 
@@ -65,6 +70,8 @@ uintptr_t sAddresses::_AddHWGraphicObjectInstances_checkIsCharacter = 0;
 uintptr_t sAddresses::_AddHWGraphicObjectInstances_checkIsCharacter_jumpOut = 0;
 uintptr_t sAddresses::HackPlayerOptionsSaveData = 0;
 uintptr_t sAddresses::ClassSerializer_EndClass = 0;
+char* sAddresses::g_byte_IsFullscreen = 0;
+uintptr_t sAddresses::_BorderlessWindow_Zeromemory_D3dPresentParameters = 0;
 
 int NEEDED_KEYBOARD_SET = 0;
 
@@ -415,6 +422,74 @@ _checkIsCharacter_out:
 	}
 }
 
+HWND FindTopWindow(DWORD pid)
+{
+	std::pair<HWND, DWORD> params = { 0, pid };
+
+	// Enumerate the windows using a lambda to process each window
+	BOOL bResult = EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL
+		{
+			auto pParams = (std::pair<HWND, DWORD>*)(lParam);
+
+			DWORD processId;
+			if (GetWindowThreadProcessId(hwnd, &processId) && processId == pParams->second)
+			{
+				// Stop enumerating
+				SetLastError(-1);
+				pParams->first = hwnd;
+				return FALSE;
+			}
+
+			// Continue enumerating
+			return TRUE;
+		}, (LPARAM)&params);
+
+	if (!bResult && GetLastError() == -1 && params.first)
+	{
+		return params.first;
+	}
+
+	return 0;
+}
+
+void MakeBorderlessWindow(HWND hwnd) {
+	auto style = GetWindowLongPtr(hwnd, GWL_STYLE);
+	auto exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+
+	style = style & ~(
+		WS_CAPTION
+		| WS_THICKFRAME
+		| WS_SYSMENU
+		| WS_MINIMIZEBOX
+		| WS_MAXIMIZEBOX
+		);
+	exStyle = exStyle & ~(
+		WS_EX_DLGMODALFRAME
+		| WS_EX_COMPOSITED
+		| WS_EX_WINDOWEDGE
+		| WS_EX_CLIENTEDGE
+		| WS_EX_LAYERED
+		| WS_EX_STATICEDGE
+		| WS_EX_TOOLWINDOW
+		| WS_EX_APPWINDOW
+		);
+
+	SetWindowLongPtr(hwnd, GWL_STYLE, style);
+	SetWindowLongPtr(hwnd, GWL_EXSTYLE, exStyle);
+}
+
+void __cdecl Hook_Memset_Set_WindowedMode(void* _this, int offset, size_t length) {
+	*sAddresses::g_byte_IsFullscreen = 0;
+
+	auto width = GetSystemMetrics(SM_CXSCREEN);
+	auto height = GetSystemMetrics(SM_CYSCREEN);
+
+	auto hwnd = FindTopWindow(GetCurrentProcessId());
+
+	MakeBorderlessWindow(hwnd);
+	SetWindowPos(hwnd, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE | SWP_NOZORDER | SWP_NOSENDCHANGING);
+}
+
 void patch()
 {
 	if (get_private_profile_bool("ImproveShadowMapResolution", TRUE))
@@ -428,6 +503,10 @@ void patch()
 
 	//PatchByte(0x2210A73, 0); // windowed... doesn't work
 	//Patch<uint32_t>(0x15D71F6, 71); // depth format
+
+	if (get_private_profile_bool("BorderlessWindow", TRUE)) {
+		InjectHook(sAddresses::_BorderlessWindow_Zeromemory_D3dPresentParameters, &Hook_Memset_Set_WindowedMode);
+	}
 
 	if (get_private_profile_bool("ImproveDrawDistance", TRUE))
 	{
@@ -506,6 +585,9 @@ void InitAddresses(eExeVersion exeVersion)
 		sAddresses::_AddHWGraphicObjectInstances_checkIsCharacter_jumpOut = 0xAFD126;
 		sAddresses::HackPlayerOptionsSaveData = 0x10B06B3;
 		sAddresses::ClassSerializer_EndClass = 0x9FB540;
+		// TODO:
+		//sAddresses::g_byte_IsFullscreen = 0x02210a73;
+		//sAddresses::_BorderlessWindow_Zeromemory_D3dPresentParameters = 0x015d7176;
 
 		ac_getNewDescriptor = (void* (__cdecl*)(uint32_t, uint32_t, uint32_t))0x9D9030;
 		ac_getDeleteDescriptor = (uint32_t(__thiscall*)(void*, void*))0x4236A0;
@@ -538,6 +620,8 @@ void InitAddresses(eExeVersion exeVersion)
 		sAddresses::_AddHWGraphicObjectInstances_checkIsCharacter_jumpOut = 0x15BFE96;
 		sAddresses::HackPlayerOptionsSaveData = 0xAD4723;
 		sAddresses::ClassSerializer_EndClass = 0x14BEB50;
+		sAddresses::g_byte_IsFullscreen = (char*)0x02210a73;
+		sAddresses::_BorderlessWindow_Zeromemory_D3dPresentParameters = 0x015d7176;
 
 		ac_getNewDescriptor = (void* (__cdecl*)(uint32_t, uint32_t, uint32_t))0x149CAD0;
 		ac_getDeleteDescriptor = (uint32_t(__thiscall*)(void*, void*))0x1466AE0;

--- a/patcher/patcher.cpp
+++ b/patcher/patcher.cpp
@@ -1,3 +1,4 @@
+#define WIN32_LEAN_AND_MEAN 1
 #include <Windows.h>
 
 #include "patcher.h"


### PR DESCRIPTION
This lets us play the game in borderless window mode (by default) and can be toggled off using BorderlessWindow=0 option in ini. It opens the way for a proper fix for #13

It works by hooking the call to the initialization method that creates the `IDirect3DDevice9`.

It sets the global `IsFullscreen` flag to `0` and then it proceeds to grab primary screen metrics, remove borders from the window and resize the game window.

attached is a pre-built version of the patch with the feature added.

[EaglePatch_borderlesswindow_ac2_uplay.zip](https://github.com/user-attachments/files/17737085/EaglePatch_borderlesswindow_ac2_uplay.zip)


_It is missing the addresses for AC1 and the retail version of AC2 as i don't own those and dont like playing AC1_

Also, a neat(?) side effect of the borderless window is, that DXVK now doesn't crash the game anymore (tested with DXVK 2.5 on windows 11)