### PR TITLE
[AC1] Better telemetry patch

### DIFF
--- a/EaglePatch/src/ac1.cpp
+++ b/EaglePatch/src/ac1.cpp
@@ -8,7 +8,7 @@
 
 #include "../shared/ini_reader.h"
 
-//#define INCLUDE_CONSOLE // add ability to allocate console window
+// #define INCLUDE_CONSOLE // add ability to allocate console window
 
 #ifdef INCLUDE_CONSOLE
 #include "../shared/console.h"
@@ -379,7 +379,7 @@ void patch()
 		PatchByte(sAddresses::_skipIntroVideos, 0xEB);
 
 	if (get_private_profile_bool("DisableTelemetry", TRUE))
-		PatchByte(sAddresses::_disableTelemetry, 0);
+		PatchByte(sAddresses::_disableTelemetry, 1);
 }
 
 void InitAddresses(eExeVersion exeVersion)
@@ -416,7 +416,7 @@ void InitAddresses(eExeVersion exeVersion)
 		sAddresses::_ps3_controls_analog[2] = 0x98D07B + 4;
 		sAddresses::_ps3_controls_analog[3] = 0x98D092 + 4;
 		sAddresses::_skipIntroVideos = 0x405495;
-		sAddresses::_disableTelemetry = 0x017382D8;
+		sAddresses::_disableTelemetry = 0x01A11974;
 		break;
 	case DIGITAL_DX10:
 		sAddresses::Pad_UpdateTimeStamps = 0x912620;
@@ -443,7 +443,7 @@ void InitAddresses(eExeVersion exeVersion)
 		sAddresses::_ps3_controls_analog[2] = 0x96D88B + 4;
 		sAddresses::_ps3_controls_analog[3] = 0x96D8A2 + 4;
 		sAddresses::_skipIntroVideos = 0x4054B5;
-		sAddresses::_disableTelemetry = 0x170D798;
+		sAddresses::_disableTelemetry = 0x0199E924;
 
 		if (get_private_profile_bool("D3D10_RemoveDuplicateResolutions", TRUE))
 		{


### PR DESCRIPTION
Flips an internal bool which makes the game skip all telemetry code