### PR TITLE
[AC1] Add support for limiting the amount of CPU cores the game can use

### DIFF
--- a/EaglePatch/EaglePatchAC1.ini
+++ b/EaglePatch/EaglePatchAC1.ini
@@ -26,3 +26,8 @@ SkipIntroVideos=0
 ; Supported values: 0 - off, 1 - on
 ; Default - 0
 DisableXInputPatch=0
+
+; Set the process affinity to run on the first four cores (fixes game crashing at startup when using a CPU with a high core count)
+; Supported values: 0 - off, 1 - on
+; Default - 0
+LimitCpuCores=0

--- a/EaglePatch/Readme - EaglePatchAC1.txt
+++ b/EaglePatch/Readme - EaglePatchAC1.txt
@@ -11,6 +11,7 @@ Features:
 - Gamepad and kb/mouse controls work at the same time (read note below)
 - Added ini setting for enabling PS3-like controls
 - Added ini setting to skip intro videos (without having to rename files)
+- Added ini setting to limit CPU cores the game can use (fixes game crashing at startup when using a CPU with a high core count)
 - [DX10 only] Fixed doubling of resolution modes in settings
 
 Note: switching controls layout in game settings has no effect anymore, if you didn't use KeyboardMouse2 layout for keyboard, you need to change KeyboardLayout setting in EaglePatchAC1.ini

--- a/EaglePatch/src/ac1.cpp
+++ b/EaglePatch/src/ac1.cpp
@@ -355,6 +355,12 @@ void patch()
 	if (NEEDED_KEYBOARD_SET < scimitar::PadSets::Keyboard1) NEEDED_KEYBOARD_SET = scimitar::PadSets::Keyboard1;
 	else if (NEEDED_KEYBOARD_SET > scimitar::PadSets::Keyboard4) NEEDED_KEYBOARD_SET = scimitar::PadSets::Keyboard4;
 
+	if (get_private_profile_bool("LimitCpuCores", FALSE))
+	{
+		// set process affinity to use first 4 cores
+		SetProcessAffinityMask(GetCurrentProcess(), 0xF);
+	}
+
 	if (!get_private_profile_bool("DisableXInputPatch", FALSE))
 	{
 		InjectHook(sAddresses::_addXenonJoy_Patch, &_addXenonJoy_Patch, PATCH_JUMP);

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ EaglePatchAC1 is an ASI plugin that fixes a number of issues in Assassin's Creed
 - Gamepad and kb/mouse controls work at the same time (read note below)
 - Added ini setting for enabling PS3-like controls
 - Added ini setting to skip intro videos (without having to rename files)
+- Added ini setting to limit CPU cores the game can use (fixes game crashing at startup when using a CPU with a high core count)
 - [DX10 only] Fixed doubling of resolution modes in settings
 
 Note: switching controls layout in game settings has no effect anymore, if you didn't use KeyboardMouse2 layout for keyboard, you need to change KeyboardLayout setting in EaglePatchAC1.ini


### PR DESCRIPTION
Fixes a crash on game startup when using a CPU with a high core count, e.g., 5950x with 16 cores